### PR TITLE
Correction of q-ary polarization procedure.

### DIFF
--- a/QaryPolarEncoderDecoder.py
+++ b/QaryPolarEncoderDecoder.py
@@ -197,7 +197,6 @@ class QaryPolarEncoderDecoder:
             if self.frozenOrInformation[uIndex] == uIndexType.information:
                 if decoding:
                     marginalizedVector = xyVectorDistribution.calcMarginalizedProbabilities()
-                    # print( marginalizedVector )
                     information[informationVectorIndex] = np.argmax(marginalizedVector)
                 encodedVector[0] = information[informationVectorIndex]
                 next_uIndex = uIndex + 1
@@ -244,7 +243,7 @@ class QaryPolarEncoderDecoder:
 
             for halfi in range(halfLength):
                 encodedVector[2*halfi] = (minusEncodedVector[halfi] + plusEncodedVector[halfi]) % self.q
-                encodedVector[2*halfi + 1] = plusEncodedVector[halfi]
+                encodedVector[2*halfi + 1] = (-plusEncodedVector[halfi] + self.q) % self.q
 
             return (encodedVector, next_uIndex, next_informationVectorIndex)
 

--- a/ScalarDistributions/QaryMemorylessDistribution.py
+++ b/ScalarDistributions/QaryMemorylessDistribution.py
@@ -749,11 +749,7 @@ class QaryMemorylessDistribution:
 # useful channels
 def makeQSC(q, p):
     qsc = QaryMemorylessDistribution(q)
-
-    for y in range(q):
-        tempProbs = [(1.0 - p)/q if x == y else p/(q*(q-1)) for x in range(q)]
-        qsc.append(tempProbs)
-    
+    qsc.probs = [[(1.0 - p) / q if x == y else p / (q * (q - 1)) for x in range(q)] for y in range(q)]
     return qsc
 
 def makeQEC(q, p):

--- a/VectorDistributions/QaryMemorylessVectorDistribution.py
+++ b/VectorDistributions/QaryMemorylessVectorDistribution.py
@@ -38,10 +38,9 @@ class QaryMemorylessVectorDistribution(VectorDistribution.VectorDistribution):
 
             u1 = uminusDecisions[halfi]
             for u2 in range(self.q):
-                x1 = (u1 - u2 + self.q) % self.q
-                x2 = u2
+                x1 = (u1 + u2) % self.q
+                x2 = (-u2 + self.q) % self.q
                 newVector.probs[halfi][u2] += self.probs[i][x1] * self.probs[i + 1][x2]
-            # print(newVector.probs[halfi][0], newVector.probs[halfi][1])
 
         return newVector
 


### PR DESCRIPTION
Instead of using the polarization matrix [[1, 0], [1, 1]], use the involutory polarization matrix [[1, 0], [1, -1]].